### PR TITLE
Theme update 2412

### DIFF
--- a/.theme-check.yml
+++ b/.theme-check.yml
@@ -1,4 +1,9 @@
+# Added because we only use EN language.
 MatchingTranslations:
   enabled: false
-TemplateLength:
+# Added this to ignore our old variable naming scheme.
+VariableName:
+  enabled: false
+# Added this to ignore multiple errors from Locksmith
+UnusedAssign:
   enabled: false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,15 +19,26 @@
         "**/node_modules": true,
         "**/vendor": true
     },
-	"editor.suggest.showSnippets": true,
-	"editor.quickSuggestions": {
-		"strings": true
-	},
-	"editor.wordWrap": "off",
-	"editor.renderFinalNewline": "on",
-	"files.insertFinalNewline": true,
-	"files.trimFinalNewlines": false,
-	"html.format.wrapLineLength": 80,
-	"editor.tabSize": 4,
-	"editor.insertSpaces": true,
+    "editor.suggest.showSnippets": true,
+    "editor.quickSuggestions": {
+        "strings": true
+    },
+    "editor.wordWrap": "off",
+    "editor.renderFinalNewline": "on",
+    "files.insertFinalNewline": true,
+    "files.trimFinalNewlines": false,
+    "html.format.wrapLineLength": 80,
+    "editor.tabSize": 4,
+    "editor.insertSpaces": true,
+    "[javascript]": {
+        "editor.formatOnSave": true
+    },
+    "[css]": {
+        "editor.formatOnSave": true
+    },
+    "[liquid]": {
+        "editor.defaultFormatter": "Shopify.theme-check-vscode",
+        "editor.formatOnSave": true
+    },
+    "themeCheck.checkOnSave": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,7 +24,7 @@
 		"strings": true
 	},
 	"editor.wordWrap": "off",
-	"editor.renderFinalNewline": true,
+	"editor.renderFinalNewline": "on",
 	"files.insertFinalNewline": true,
 	"files.trimFinalNewlines": false,
 	"html.format.wrapLineLength": 80,

--- a/layout/password.liquid
+++ b/layout/password.liquid
@@ -215,10 +215,10 @@
     {% endstyle %}
 
     {%- unless settings.type_body_font.system? -%}
-      <link rel="preload" as="font" href="{{ settings.type_body_font | font_url }}" type="font/woff2" crossorigin>
+      {{ settings.type_body_font | font_url | preload_tag: as: 'font', type: 'font/woff2', crossorigin: 'anonymous' }}
     {%- endunless -%}
     {%- unless settings.type_header_font.system? -%}
-      <link rel="preload" as="font" href="{{ settings.type_header_font | font_url }}" type="font/woff2" crossorigin>
+      {{ settings.type_header_font | font_url | preload_tag: as: 'font', type: 'font/woff2', crossorigin: 'anonymous' }}
     {%- endunless -%}
 
     {{ 'section-password.css' | asset_url | stylesheet_tag }}

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -1,31 +1,31 @@
 {%- comment %}<locksmith:aab6>{% endcomment -%}
-  {%- include 'locksmith' -%}
+  {%- render 'locksmith' -%}
 {%- comment %}</locksmith:aab6>{% endcomment -%}
 
 <!doctype html>
 <html class="no-js" lang="{{ request.locale.iso_code }}">
   <head> 
-    {{ locksmith_initializations }}
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     
     <link rel="preconnect" href="https://cdn.shopify.com" crossorigin>
+    <link rel="preconnect" href="https://www.googletagmanager.com/" crossorigin="anonymous">
+    <link rel="preconnect" href="https://cmp.osano.com/" crossorigin="anonymous">
     {%- unless settings.type_header_font.system? and settings.type_body_font.system? -%}
       <link rel="preconnect" href="https://fonts.shopifycdn.com" crossorigin>
     {%- endunless -%}
+
+    {{ locksmith_initializations }}
     
     {%- unless settings.type_body_font.system? -%}
-      <link rel="preload" as="font" href="{{ settings.type_body_font | font_url }}" type="font/woff2" crossorigin>
+      {{ settings.type_body_font | font_url | preload_tag: as: 'font', type: 'font/woff2', crossorigin: 'anonymous' }}
     {%- endunless -%}
     
     {%- unless settings.type_header_font.system? -%}
-      <link rel="preload" as="font" href="{{ settings.type_header_font | font_url }}" type="font/woff2" crossorigin>
+      {{ settings.type_header_font | font_url | preload_tag: as: 'font', type: 'font/woff2', crossorigin: 'anonymous' }}
     {%- endunless -%}
-    
-    <link rel="dns-prefetch" href="https://www.googletagmanager.com/" >
-    <link rel="dns-prefetch" href="https://cmp.osano.com/" >
-    
+        
     <title>
       {{ page_title }}
       {%- if current_tags %}
@@ -334,8 +334,8 @@
 
     {{ 'zify-sizechart.css' | asset_url | stylesheet_tag }}
    
-    <script src="https://cmp.osano.com/16A0DbT9yDNIaQkvZ/c3494b1e-ff3a-436f-978d-842e9a0bed27/osano.js"></script>
-
+    <script src="https://cmp.osano.com/16A0DbT9yDNIaQkvZ/c3494b1e-ff3a-436f-978d-842e9a0bed27/osano.js" defer></script>
+    
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -356,15 +356,9 @@
     </script>
     
     <script src="{{ 'global.js' | asset_url }}" defer="defer"></script>
-    
-    
-
-  <!-- Avada Email Marketing Script -->
- {% include 'avada-em-setting' %}
-  <!-- /Avada Email Marketing Script -->
-
-{{ content_for_header }}
-    
+  
+    {% render 'avada-em-setting' %}
+   
     <script>
       document.documentElement.className = document.documentElement.className.replace('no-js', 'js');
       if (Shopify.designMode) {
@@ -385,6 +379,7 @@
 
     <link rel="canonical" href="{{ canonical_url }}">
     {% render 'meta-tags' %}   
+    {{ content_for_header }}
 </head>
 
   <body class="gradient">
@@ -448,6 +443,6 @@
     {%- if settings.predictive_search_enabled -%}
       <script src="{{ 'predictive-search.js' | asset_url }}" defer="defer"></script>
     {%- endif -%}
-  <script src='{{ 'zify-sizechart.js' | asset_url }}' defer='defer'></script>
+    <script src='{{ 'zify-sizechart.js' | asset_url }}' defer='defer'></script>
 </body>
 </html>

--- a/sections/collection-list.liquid
+++ b/sections/collection-list.liquid
@@ -88,7 +88,7 @@
   "name": "t:sections.collection-list.name",
   "tag": "section",
   "class": "section section-collection-list",
-  "max_blocks": 100,
+  "max_blocks": 50,
   "settings": [
     {
       "type": "text",

--- a/sections/email-signup-banner.liquid
+++ b/sections/email-signup-banner.liquid
@@ -380,9 +380,6 @@
         }
       ]
     }
-  ],
-  "templates": [
-    "password"
   ]
 }
 {% endschema %}

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -2322,7 +2322,7 @@
     vendor: {{ product.vendor|json }},
     productType: {{ product.type|json }},
     collections: {{ product.collections|map:'title'|json }},
-    image: "https:{{ product.featured_image.src|img_url:'grande' }}",
+    image: "https:{{ product.featured_image | image_url: size: 'grande' }}",
     url: "{{ shop.secure_url }}{{ product.url }}",
     price: {{ product.price |json }},
     tags: {{ product.tags |json }},

--- a/snippets/avada-em-setting.liquid
+++ b/snippets/avada-em-setting.liquid
@@ -1,6 +1,6 @@
 
-{% include 'avada-em-status' %}
-{% include 'avada-em-popup-cache' %}
+{% render 'avada-em-status' %}
+{% render 'avada-em-popup-cache' %}
 {% assign scripttags = content_for_header | split: 'var urls = ["' %}
 {% if scripttags.size > 1 %}
   {% assign scripttags = scripttags[1] %}

--- a/snippets/locksmith.liquid
+++ b/snippets/locksmith.liquid
@@ -7,7 +7,7 @@
   Last updated: Fri, 20 Sep 2024 08:59:06 -0400 (EDT)
 {% endcomment -%}
 
-{%include 'locksmith-variables', locksmith_scope: nil%}{%if locksmith_access_denied_content == blank%}{%capture locksmith_access_denied_content%}{%if locksmith_manual_lock%}{{content_for_layout}}{%elsif locksmith_remote_lock%}<div id="locksmith-content">
+{% render 'locksmith-variables', locksmith_scope: nil%}{%if locksmith_access_denied_content == blank%}{%capture locksmith_access_denied_content%}{%if locksmith_manual_lock%}{{content_for_layout}}{%elsif locksmith_remote_lock%}<div id="locksmith-content">
         <div id="locksmith-spinner-wrapper" style="background:#FFF;z-index:999999;top:0;left:0;right:0;bottom:0;position:fixed">
           <style>
             @keyframes spin { from { transform: rotate(0deg) } to { transform: rotate(360deg) } }
@@ -69,7 +69,7 @@
         } else {
           window.addEventListener('load', load);
         }
-      </script>{%endif%}{%endcapture%}{%endif%}{%include 'locksmith-content-variables'%}{%include 'locksmith-variables', locksmith_scope: nil%}{%if locksmith_access_denied%}{%capture content_for_header%}{{content_for_header|replace:'.oembed', ''|replace:'.atom', ''|replace:'link rel="alternate" type="application/json+oembed"', 'link'|replace:' title="Feed" rel="alternate" type="application/atom+xml"', ''}}{%endcapture%}{%endif%}{%capture locksmith_initializations%}{%if locksmith_access_denied and locksmith_manual_lock == false and locksmith_noindex%}<meta name="robots" content="noindex" />{%endif%}{{locksmith_json}}{{locksmith_client}}
+      </script>{%endif%}{%endcapture%}{%endif%}{% render 'locksmith-content-variables'%}{% render 'locksmith-variables', locksmith_scope: nil%}{%if locksmith_access_denied%}{%capture content_for_header%}{{content_for_header|replace:'.oembed', ''|replace:'.atom', ''|replace:'link rel="alternate" type="application/json+oembed"', 'link'|replace:' title="Feed" rel="alternate" type="application/atom+xml"', ''}}{%endcapture%}{%endif%}{%capture locksmith_initializations%}{%if locksmith_access_denied and locksmith_manual_lock == false and locksmith_noindex%}<meta name="robots" content="noindex" />{%endif%}{{locksmith_json}}{{locksmith_client}}
 
   <script data-locksmith>Locksmith.jsonTag={{locksmith_json|json}};Locksmith.jsonTagSignature={{locksmith_json_signature|json}}</script>{%endcapture%}{%if locksmith_access_granted or locksmith_manual_lock%}{%if locksmith_redirect != blank%}{%assign content_for_layout=locksmith_redirect%}{%endif%}{%else%}{%assign content_for_layout=locksmith_access_denied_content%}{%endif%}{%capture _3%}<script data-locksmith>
     var load = function () {

--- a/templates/gift_card.liquid
+++ b/templates/gift_card.liquid
@@ -86,10 +86,10 @@
     {% endstyle %}
 
     {%- unless settings.type_body_font.system? -%}
-      <link rel="preload" as="font" href="{{ settings.type_body_font | font_url }}" type="font/woff2" crossorigin>
+      {{ settings.type_body_font | font_url | preload_tag: as: 'font', type: 'font/woff2', crossorigin: 'anonymous' }}
     {%- endunless -%}
     {%- unless settings.type_header_font.system? -%}
-      <link rel="preload" as="font" href="{{ settings.type_header_font | font_url }}" type="font/woff2" crossorigin>
+      {{ settings.type_header_font | font_url | preload_tag: as: 'font', type: 'font/woff2', crossorigin: 'anonymous' }}
     {%- endunless -%}
 
     {{ 'template-giftcard.css' | asset_url | stylesheet_tag }}


### PR DESCRIPTION
- Adds some ignore rule to the theme check
- Changes some preload implementation
- Changes include to render - include is deprecated
- Reorder and lints the the header of the theme template  
- Fixes section liquid files where their schema was incorrect 

I have not been able to test this on the CNCF store, as my access has been removed. 